### PR TITLE
Add and Delete favorite Sports

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@expo/webpack-config": "^0.17.0",
         "@react-native-community/datetimepicker": "6.2.0",
+        "@react-native-picker/picker": "2.4.8",
         "@react-navigation/native-stack": "^6.9.1",
         "@rneui/base": "^4.0.0-rc.6",
         "@rneui/themed": "^4.0.0-rc.6",
@@ -4588,6 +4589,15 @@
       "peer": true,
       "peerDependencies": {
         "react": ">=16.0",
+        "react-native": ">=0.57"
+      }
+    },
+    "node_modules/@react-native-picker/picker": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.4.8.tgz",
+      "integrity": "sha512-5NQ5XPo1B03YNqKFrV6h9L3CQaHlB80wd4ETHUEABRP2iLh7FHLVObX2GfziD+K/VJb8G4KZcZ23NFBFP1f7bg==",
+      "peerDependencies": {
+        "react": ">=16",
         "react-native": ">=0.57"
       }
     },
@@ -23714,6 +23724,12 @@
       "resolved": "https://registry.npmjs.org/@react-native-community/masked-view/-/masked-view-0.1.11.tgz",
       "integrity": "sha512-rQfMIGSR/1r/SyN87+VD8xHHzDYeHaJq6elOSCAD+0iLagXkSI2pfA0LmSXP21uw5i3em7GkkRjfJ8wpqWXZNw==",
       "peer": true,
+      "requires": {}
+    },
+    "@react-native-picker/picker": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.4.8.tgz",
+      "integrity": "sha512-5NQ5XPo1B03YNqKFrV6h9L3CQaHlB80wd4ETHUEABRP2iLh7FHLVObX2GfziD+K/VJb8G4KZcZ23NFBFP1f7bg==",
       "requires": {}
     },
     "@react-native/assets": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "@react-navigation/native-stack": "^6.9.1",
     "@rneui/base": "^4.0.0-rc.6",
     "@rneui/themed": "^4.0.0-rc.6",
+    "@react-native-picker/picker": "2.4.8",
     "expo": "~46.0.16",
     "expo-app-loading": "^2.1.0",
     "expo-font": "^10.2.1",

--- a/frontend/screens/EditSettings.js
+++ b/frontend/screens/EditSettings.js
@@ -123,7 +123,7 @@ const EditSettings = ({route}) => {
       <Pressable
         style={styles.buttonPressable1}
         onPress={() => navigation.navigate("EditProfile", {username: route.params.username,
-          bio: route.params.bio})}
+          bio: route.params.bio, favoriteSports: route.params.favoriteSports})}
       >
         <Image
           style={styles.leadingIcon2}

--- a/frontend/screens/ProfileUser.js
+++ b/frontend/screens/ProfileUser.js
@@ -46,7 +46,9 @@ const ProfileUser = () => {
         fetch(`http://${LOCAL_IP}:3000/sports/favorite`)
         .then((res) => {return res.json()})
         .then((res) => {
-          setSportInfo(res.data)
+          if(res.data != undefined){
+            setSportInfo(res.data)
+          }
         })
         .catch((e) => {console.log(e)})
       }).catch((e) => {console.log(e)})
@@ -224,7 +226,8 @@ const ProfileUser = () => {
           onPress={() => navigation.navigate("EditSettings", {
             username: username,
             bio: bio,
-            email: email
+            email: email,
+            favoriteSports: favoriteSports,
           })}
         >
           <Image
@@ -295,16 +298,13 @@ const ProfileUser = () => {
         
         {
           //Please do your CSS magic Thomas to get these to align property thx
-          favoriteSports.length
-          ?
+          
           favoriteSports.map((sport) => {
             favoriteSportAdjustment = favoriteSportAdjustment + 6
             let topPercentage = favoriteSportAdjustment + "%"
 
             return <Text style={{position: "absolute", top: topPercentage, left: 70, fontSize: 14, fontFamily: "GearUp", color: "#000", textAlign: "left"}} key={sport.sport_id}> {sport.sport_name} </Text> 
         })
-          :
-          <Text> empty </Text>
         }
         
         <SafeAreaView style={styles.lineView} />


### PR DESCRIPTION
This was pain. Add and Delete favorite sports. Thomas, please fix the styling as you see fit. The delete buttons in particular are rather scuffed. They work but you just have to keep clicking around the stretched image until it works. Also, I couldn't get dynamic images to work for the favorite sports icons. Something to do with the require() calls occurring at compile time so variables aren't able to be used since they are created at runtime. I used @react-native-picker/picker version 2.4.8 for adding the sports. You'll notice a warning upon doing an npm install and running npx expo start, caused by some sort of conflict between the expo version and the picker. I tried using the earlier version of the picker (2.4.2) that the error recommends but for some reason it doesn't work. Found a post (https://github.com/react-native-picker/picker/issues/425) where people were having the same problem and as far as I am aware it hasn't been fixed. As far as I could tell, the picker didn't cause any problems with the rest of the app so I think it should be okay. The code should work if/when we add more possible sports to choose from but the cards would start running off the page if the user were to favorite more than 4 or 5 sports. I can set a limit to the number of sports a player can favorite if this comes to be a problem later on.